### PR TITLE
Extract edit history to new pallets

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -699,13 +699,16 @@ dependencies = [
  "frame-support",
  "frame-system",
  "pallet-permissions",
+ "pallet-post-history",
  "pallet-posts",
  "pallet-profile-follows",
+ "pallet-profile-history",
  "pallet-profiles",
  "pallet-reactions",
  "pallet-roles",
  "pallet-scores",
  "pallet-space-follows",
+ "pallet-space-history",
  "pallet-space-ownership",
  "pallet-spaces",
  "pallet-timestamp",
@@ -2754,6 +2757,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "pallet-post-history"
+version = "2.0.0"
+dependencies = [
+ "frame-support",
+ "frame-system",
+ "impl-trait-for-tuples",
+ "pallet-posts",
+ "pallet-utils",
+ "parity-scale-codec",
+ "sp-runtime",
+ "sp-std",
+]
+
+[[package]]
 name = "pallet-posts"
 version = "2.0.0"
 dependencies = [
@@ -2781,11 +2798,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "pallet-profile-history"
+version = "2.0.0"
+dependencies = [
+ "frame-support",
+ "frame-system",
+ "pallet-profiles",
+ "pallet-utils",
+ "parity-scale-codec",
+ "sp-runtime",
+ "sp-std",
+]
+
+[[package]]
 name = "pallet-profiles"
 version = "2.0.0"
 dependencies = [
  "frame-support",
  "frame-system",
+ "impl-trait-for-tuples",
  "pallet-permissions",
  "pallet-utils",
  "parity-scale-codec",
@@ -2891,6 +2922,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "pallet-space-history"
+version = "2.0.0"
+dependencies = [
+ "frame-support",
+ "frame-system",
+ "pallet-spaces",
+ "pallet-utils",
+ "parity-scale-codec",
+ "sp-runtime",
+ "sp-std",
+]
+
+[[package]]
 name = "pallet-space-ownership"
 version = "2.0.0"
 dependencies = [
@@ -2909,6 +2953,7 @@ dependencies = [
  "df-traits",
  "frame-support",
  "frame-system",
+ "impl-trait-for-tuples",
  "pallet-permissions",
  "pallet-utils",
  "parity-scale-codec",
@@ -5198,14 +5243,17 @@ dependencies = [
  "pallet-grandpa",
  "pallet-indices",
  "pallet-permissions",
+ "pallet-post-history",
  "pallet-posts",
  "pallet-profile-follows",
+ "pallet-profile-history",
  "pallet-profiles",
  "pallet-randomness-collective-flip",
  "pallet-reactions",
  "pallet-roles",
  "pallet-scores",
  "pallet-space-follows",
+ "pallet-space-history",
  "pallet-space-ownership",
  "pallet-spaces",
  "pallet-sudo",

--- a/pallets/df-integration-tests/Cargo.toml
+++ b/pallets/df-integration-tests/Cargo.toml
@@ -21,13 +21,16 @@ std = [
     'pallet-timestamp/std',
     "pallet-permissions/std",
     "pallet-posts/std",
+    "pallet-post-history/std",
     "pallet-profiles/std",
+    "pallet-profile-history/std",
     "pallet-profile-follows/std",
     "pallet-reactions/std",
     "pallet-roles/std",
     "pallet-scores/std",
     "pallet-spaces/std",
     "pallet-space-follows/std",
+    "pallet-space-history/std",
     "pallet-space-ownership/std",
     "pallet-utils/std"
 ]
@@ -77,9 +80,17 @@ path = "../permissions"
 default-features = false
 path = "../posts"
 
+[dependencies.pallet-post-history]
+default-features = false
+path = "../post-history"
+
 [dependencies.pallet-profiles]
 default-features = false
 path = "../profiles"
+
+[dependencies.pallet-profile-history]
+default-features = false
+path = "../profile-history"
 
 [dependencies.pallet-profile-follows]
 default-features = false
@@ -104,6 +115,10 @@ path = "../spaces"
 [dependencies.pallet-space-follows]
 default-features = false
 path = "../space-follows"
+
+[dependencies.pallet-space-history]
+default-features = false
+path = "../space-history"
 
 [dependencies.pallet-space-ownership]
 default-features = false

--- a/pallets/df-integration-tests/src/lib.rs
+++ b/pallets/df-integration-tests/src/lib.rs
@@ -935,7 +935,7 @@ mod tests {
 
             assert_eq!(space.posts_count, 0);
             assert_eq!(space.followers_count, 1);
-            assert!(SpaceHistory::space_history_by_space_id(space.id).is_empty());
+            assert!(SpaceHistory::edit_history(space.id).is_empty());
             assert_eq!(space.score, 0);
         });
     }
@@ -1092,7 +1092,7 @@ mod tests {
             assert_eq!(space.hidden, true);
 
             // Check whether history recorded correctly
-            let edit_history = &SpaceHistory::space_history_by_space_id(space.id)[0];
+            let edit_history = &SpaceHistory::edit_history(space.id)[0];
             assert_eq!(edit_history.old_data.handle, Some(Some(self::space_handle())));
             assert_eq!(edit_history.old_data.content, Some(self::space_content_ipfs()));
             assert_eq!(edit_history.old_data.hidden, Some(false));
@@ -1391,7 +1391,7 @@ mod tests {
 
             assert_eq!(post.score, 0);
 
-            assert!(PostHistory::post_history_by_post_id(POST1).is_empty());
+            assert!(PostHistory::edit_history(POST1).is_empty());
         });
     }
 
@@ -1492,7 +1492,7 @@ mod tests {
             assert_eq!(post.hidden, true);
 
             // Check whether history recorded correctly
-            let post_history = PostHistory::post_history_by_post_id(POST1)[0].clone();
+            let post_history = PostHistory::edit_history(POST1)[0].clone();
             assert!(post_history.old_data.space_id.is_none());
             assert_eq!(post_history.old_data.content, Some(self::post_content_ipfs()));
             assert_eq!(post_history.old_data.hidden, Some(false));
@@ -1682,7 +1682,7 @@ mod tests {
             assert_eq!(comment.downvotes_count, 0);
             assert_eq!(comment.score, 0);
 
-            assert!(PostHistory::post_history_by_post_id(POST2).is_empty());
+            assert!(PostHistory::edit_history(POST2).is_empty());
         });
     }
 
@@ -1801,7 +1801,7 @@ mod tests {
             assert_eq!(comment.content, self::reply_content_ipfs());
 
             // Check whether history recorded correctly
-            assert_eq!(PostHistory::post_history_by_post_id(POST2)[0].old_data.content, Some(self::comment_content_ipfs()));
+            assert_eq!(PostHistory::edit_history(POST2)[0].old_data.content, Some(self::comment_content_ipfs()));
         });
     }
 
@@ -2637,7 +2637,7 @@ mod tests {
             assert_eq!(profile.content, self::profile_content_ipfs());
             assert_eq!(Profiles::account_by_profile_username(self::alice_username()), Some(ACCOUNT1));
 
-            assert!(ProfileHistory::profile_history_by_account(ACCOUNT1).is_empty());
+            assert!(ProfileHistory::edit_history(ACCOUNT1).is_empty());
         });
     }
 
@@ -2743,7 +2743,7 @@ mod tests {
             assert_eq!(Profiles::account_by_profile_username(self::bob_username()), Some(ACCOUNT1));
 
             // Check whether profile history is written correctly
-            let profile_history = ProfileHistory::profile_history_by_account(ACCOUNT1)[0].clone();
+            let profile_history = ProfileHistory::edit_history(ACCOUNT1)[0].clone();
             assert_eq!(profile_history.old_data.username, Some(self::alice_username()));
             assert_eq!(profile_history.old_data.content, Some(self::profile_content_ipfs()));
         });

--- a/pallets/df-integration-tests/src/lib.rs
+++ b/pallets/df-integration-tests/src/lib.rs
@@ -161,7 +161,12 @@ mod tests {
         type Event = ();
         type MaxCommentDepth = MaxCommentDepth;
         type PostScores = Scores;
+        type AfterPostUpdated = PostHistory;
     }
+
+    parameter_types! {}
+
+    impl pallet_post_history::Trait for TestRuntime {}
 
     parameter_types! {}
 
@@ -180,7 +185,12 @@ mod tests {
         type Event = ();
         type MinUsernameLen = MinUsernameLen;
         type MaxUsernameLen = MaxUsernameLen;
+        type AfterProfileUpdated = ProfileHistory;
     }
+
+    parameter_types! {}
+
+    impl pallet_profile_history::Trait for TestRuntime {}
 
     parameter_types! {}
 
@@ -256,16 +266,24 @@ mod tests {
         type Roles = Roles;
         type SpaceFollows = SpaceFollows;
         type BeforeSpaceCreated = SpaceFollows;
+        type AfterSpaceUpdated = SpaceHistory;
     }
+
+    parameter_types! {}
+
+    impl pallet_space_history::Trait for TestRuntime {}
 
     type System = system::Module<TestRuntime>;
     type Posts = pallet_posts::Module<TestRuntime>;
+    type PostHistory = pallet_post_history::Module<TestRuntime>;
     type ProfileFollows = pallet_profile_follows::Module<TestRuntime>;
     type Profiles = pallet_profiles::Module<TestRuntime>;
+    type ProfileHistory = pallet_profile_history::Module<TestRuntime>;
     type Reactions = pallet_reactions::Module<TestRuntime>;
     type Roles = pallet_roles::Module<TestRuntime>;
     type Scores = pallet_scores::Module<TestRuntime>;
     type SpaceFollows = pallet_space_follows::Module<TestRuntime>;
+    type SpaceHistory = pallet_space_history::Module<TestRuntime>;
     type SpaceOwnership = pallet_space_ownership::Module<TestRuntime>;
     type Spaces = pallet_spaces::Module<TestRuntime>;
 
@@ -917,7 +935,7 @@ mod tests {
 
             assert_eq!(space.posts_count, 0);
             assert_eq!(space.followers_count, 1);
-            assert!(space.edit_history.is_empty());
+            assert!(SpaceHistory::space_history_by_space_id(space.id).is_empty());
             assert_eq!(space.score, 0);
         });
     }
@@ -1074,9 +1092,10 @@ mod tests {
             assert_eq!(space.hidden, true);
 
             // Check whether history recorded correctly
-            assert_eq!(space.edit_history[0].old_data.handle, Some(Some(self::space_handle())));
-            assert_eq!(space.edit_history[0].old_data.content, Some(self::space_content_ipfs()));
-            assert_eq!(space.edit_history[0].old_data.hidden, Some(false));
+            let edit_history = &SpaceHistory::space_history_by_space_id(space.id)[0];
+            assert_eq!(edit_history.old_data.handle, Some(Some(self::space_handle())));
+            assert_eq!(edit_history.old_data.content, Some(self::space_content_ipfs()));
+            assert_eq!(edit_history.old_data.hidden, Some(false));
         });
     }
 
@@ -1364,7 +1383,6 @@ mod tests {
             assert_eq!(post.extension, self::extension_regular_post());
 
             assert_eq!(post.content, self::post_content_ipfs());
-            assert!(post.edit_history.is_empty());
 
             assert_eq!(post.total_replies_count, 0);
             assert_eq!(post.shares_count, 0);
@@ -1372,6 +1390,8 @@ mod tests {
             assert_eq!(post.downvotes_count, 0);
 
             assert_eq!(post.score, 0);
+
+            assert!(PostHistory::post_history_by_post_id(POST1).is_empty());
         });
     }
 
@@ -1472,9 +1492,10 @@ mod tests {
             assert_eq!(post.hidden, true);
 
             // Check whether history recorded correctly
-            assert!(post.edit_history[0].old_data.space_id.is_none());
-            assert_eq!(post.edit_history[0].old_data.content, Some(self::post_content_ipfs()));
-            assert_eq!(post.edit_history[0].old_data.hidden, Some(false));
+            let post_history = PostHistory::post_history_by_post_id(POST1)[0].clone();
+            assert!(post_history.old_data.space_id.is_none());
+            assert_eq!(post_history.old_data.content, Some(self::post_content_ipfs()));
+            assert_eq!(post_history.old_data.hidden, Some(false));
         });
     }
 
@@ -1655,12 +1676,13 @@ mod tests {
             assert_eq!(comment.created.account, ACCOUNT1);
             assert!(comment.updated.is_none());
             assert_eq!(comment.content, self::comment_content_ipfs());
-            assert!(comment.edit_history.is_empty());
             assert_eq!(comment.total_replies_count, 0);
             assert_eq!(comment.shares_count, 0);
             assert_eq!(comment.upvotes_count, 0);
             assert_eq!(comment.downvotes_count, 0);
             assert_eq!(comment.score, 0);
+
+            assert!(PostHistory::post_history_by_post_id(POST2).is_empty());
         });
     }
 
@@ -1779,7 +1801,7 @@ mod tests {
             assert_eq!(comment.content, self::reply_content_ipfs());
 
             // Check whether history recorded correctly
-            assert_eq!(comment.edit_history[0].old_data.content, Some(self::comment_content_ipfs()));
+            assert_eq!(PostHistory::post_history_by_post_id(POST2)[0].old_data.content, Some(self::comment_content_ipfs()));
         });
     }
 
@@ -2613,8 +2635,9 @@ mod tests {
             assert!(profile.updated.is_none());
             assert_eq!(profile.username, self::alice_username());
             assert_eq!(profile.content, self::profile_content_ipfs());
-            assert!(profile.edit_history.is_empty());
             assert_eq!(Profiles::account_by_profile_username(self::alice_username()), Some(ACCOUNT1));
+
+            assert!(ProfileHistory::profile_history_by_account(ACCOUNT1).is_empty());
         });
     }
 
@@ -2720,8 +2743,9 @@ mod tests {
             assert_eq!(Profiles::account_by_profile_username(self::bob_username()), Some(ACCOUNT1));
 
             // Check whether profile history is written correctly
-            assert_eq!(profile.edit_history[0].old_data.username, Some(self::alice_username()));
-            assert_eq!(profile.edit_history[0].old_data.content, Some(self::profile_content_ipfs()));
+            let profile_history = ProfileHistory::profile_history_by_account(ACCOUNT1)[0].clone();
+            assert_eq!(profile_history.old_data.username, Some(self::alice_username()));
+            assert_eq!(profile_history.old_data.content, Some(self::profile_content_ipfs()));
         });
     }
 

--- a/pallets/post-history/Cargo.toml
+++ b/pallets/post-history/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
-name = "pallet-spaces"
+name = "pallet-post-history"
 version = "2.0.0"
 authors = ["DappForce <dappforce@pm.me>"]
 edition = "2018"
 license = "GPL-3.0-only"
 homepage = "https://subsocial.network"
 repository = "https://github.com/dappforce/dappforce-subsocial-node"
-description = "Space management pallet"
+description = "Pallet that stores post updates history"
 keywords = ["blockchain", "cryptocurrency", "social-network", "news-feed", "marketplace"]
 categories = ["cryptography::cryptocurrencies"]
 
@@ -19,12 +19,11 @@ std = [
     'system/std',
     'sp-std/std',
     'pallet-utils/std',
-    'df-traits/std',
-    'pallet-permissions/std'
+    'pallet-posts/std'
 ]
 
-[dependencies.impl-trait-for-tuples]
-version = "0.1.3"
+[dependencies]
+impl-trait-for-tuples = "0.1.3"
 
 [dependencies.codec]
 default-features = false
@@ -57,17 +56,12 @@ git = 'https://github.com/paritytech/substrate.git'
 rev = '3e651110aa06aa835790df63410a29676243fc54'
 version = '2.0.0'
 
-[dependencies.df-traits]
-default-features = false
-path = '../traits'
-version = '2.0.0'
-
 [dependencies.pallet-utils]
 default-features = false
 path = '../utils'
 version = '2.0.0'
 
-[dependencies.pallet-permissions]
+[dependencies.pallet-posts]
 default-features = false
-path = '../permissions'
+path = '../posts'
 version = '2.0.0'

--- a/pallets/post-history/Cargo.toml
+++ b/pallets/post-history/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 license = "GPL-3.0-only"
 homepage = "https://subsocial.network"
 repository = "https://github.com/dappforce/dappforce-subsocial-node"
-description = "Pallet that stores post updates history"
+description = "Pallet that stores post edit history"
 keywords = ["blockchain", "cryptocurrency", "social-network", "news-feed", "marketplace"]
 categories = ["cryptography::cryptocurrencies"]
 

--- a/pallets/post-history/src/lib.rs
+++ b/pallets/post-history/src/lib.rs
@@ -24,7 +24,7 @@ pub trait Trait: system::Trait
 // This pallet's storage items.
 decl_storage! {
     trait Store for Module<T: Trait> as PostHistoryModule {
-        pub PostHistoryByPostId get(fn post_history_by_post_id): map PostId => Vec<PostHistoryRecord<T>>;
+        pub EditHistory get(fn edit_history): map PostId => Vec<PostHistoryRecord<T>>;
     }
 }
 
@@ -46,6 +46,6 @@ impl<T: Trait> AfterPostUpdated<T> for Module<T> {
         let mut new_history_record = PostHistoryRecord::<T>::new(sender);
         new_history_record.old_data = old_data;
 
-        <PostHistoryByPostId<T>>::mutate(post.id, |ids| ids.push(new_history_record));
+        <EditHistory<T>>::mutate(post.id, |ids| ids.push(new_history_record));
     }
 }

--- a/pallets/post-history/src/lib.rs
+++ b/pallets/post-history/src/lib.rs
@@ -1,0 +1,51 @@
+#![cfg_attr(not(feature = "std"), no_std)]
+#![allow(clippy::string_lit_as_bytes)]
+
+use codec::{Decode, Encode};
+use frame_support::{decl_module, decl_storage};
+use sp_runtime::RuntimeDebug;
+use sp_std::prelude::Vec;
+
+use pallet_posts::{PostId, Post, PostUpdate, AfterPostUpdated};
+use pallet_utils::WhoAndWhen;
+
+#[derive(Encode, Decode, Clone, Eq, PartialEq, RuntimeDebug)]
+pub struct PostHistoryRecord<T: Trait> {
+    pub edited: WhoAndWhen<T>,
+    pub old_data: PostUpdate,
+}
+
+/// The pallet's configuration trait.
+pub trait Trait: system::Trait
+    + pallet_utils::Trait
+    + pallet_posts::Trait
+{}
+
+// This pallet's storage items.
+decl_storage! {
+    trait Store for Module<T: Trait> as PostHistoryModule {
+        pub PostHistoryByPostId get(fn post_history_by_post_id): map PostId => Vec<PostHistoryRecord<T>>;
+    }
+}
+
+decl_module! {
+  pub struct Module<T: Trait> for enum Call where origin: T::Origin {}
+}
+
+impl<T: Trait> PostHistoryRecord<T> {
+    fn new(updated_by: T::AccountId) -> Self {
+        PostHistoryRecord {
+            edited: WhoAndWhen::<T>::new(updated_by),
+            old_data: PostUpdate::default()
+        }
+    }
+}
+
+impl<T: Trait> AfterPostUpdated<T> for Module<T> {
+    fn after_post_updated(sender: T::AccountId, post: &Post<T>, old_data: PostUpdate) {
+        let mut new_history_record = PostHistoryRecord::<T>::new(sender);
+        new_history_record.old_data = old_data;
+
+        <PostHistoryByPostId<T>>::mutate(post.id, |ids| ids.push(new_history_record));
+    }
+}

--- a/pallets/post-history/src/lib.rs
+++ b/pallets/post-history/src/lib.rs
@@ -33,19 +33,17 @@ decl_module! {
 }
 
 impl<T: Trait> PostHistoryRecord<T> {
-    fn new(updated_by: T::AccountId) -> Self {
+    fn new(updated_by: T::AccountId, old_data: PostUpdate) -> Self {
         PostHistoryRecord {
             edited: WhoAndWhen::<T>::new(updated_by),
-            old_data: PostUpdate::default()
+            old_data
         }
     }
 }
 
 impl<T: Trait> AfterPostUpdated<T> for Module<T> {
     fn after_post_updated(sender: T::AccountId, post: &Post<T>, old_data: PostUpdate) {
-        let mut new_history_record = PostHistoryRecord::<T>::new(sender);
-        new_history_record.old_data = old_data;
-
-        <EditHistory<T>>::mutate(post.id, |ids| ids.push(new_history_record));
+        <EditHistory<T>>::mutate(post.id, |ids|
+            ids.push(PostHistoryRecord::<T>::new(sender, old_data)));
     }
 }

--- a/pallets/post-history/types.json
+++ b/pallets/post-history/types.json
@@ -1,0 +1,6 @@
+{
+  "PostHistoryRecord": {
+    "edited": "WhoAndWhen",
+    "old_data": "PostUpdate"
+  }
+}

--- a/pallets/posts/Cargo.toml
+++ b/pallets/posts/Cargo.toml
@@ -23,8 +23,8 @@ std = [
     'pallet-spaces/std'
 ]
 
-[dependencies]
-impl-trait-for-tuples = "0.1.3"
+[dependencies.impl-trait-for-tuples]
+version = "0.1.3"
 
 [dependencies.codec]
 default-features = false

--- a/pallets/posts/src/functions.rs
+++ b/pallets/posts/src/functions.rs
@@ -22,7 +22,6 @@ impl<T: Trait> Post<T> {
             space_id: space_id_opt,
             content,
             hidden: false,
-            edit_history: Vec::new(),
             direct_replies_count: 0,
             total_replies_count: 0,
             shares_count: 0,
@@ -124,6 +123,16 @@ impl<T: Trait> Post<T> {
             self.score = self.score.saturating_add(diff.abs() as i32);
         } else if diff < 0 {
             self.score = self.score.saturating_sub(diff.abs() as i32);
+        }
+    }
+}
+
+impl Default for PostUpdate {
+    fn default() -> Self {
+        PostUpdate {
+            space_id: None,
+            content: None,
+            hidden: None
         }
     }
 }

--- a/pallets/posts/src/lib.rs
+++ b/pallets/posts/src/lib.rs
@@ -105,7 +105,7 @@ pub trait AfterPostUpdated<T: Trait> {
 
 // This pallet's storage items.
 decl_storage! {
-    trait Store for Module<T: Trait> as TemplateModule {
+    trait Store for Module<T: Trait> as PostsModule {
         pub NextPostId get(fn next_post_id): PostId = 1;
         pub PostById get(fn post_by_id): map PostId => Option<Post<T>>;
         pub ReplyIdsByPostId get(fn reply_ids_by_post_id): map PostId => Vec<PostId>;

--- a/pallets/posts/types.json
+++ b/pallets/posts/types.json
@@ -12,8 +12,6 @@
     "content": "Content",
     "hidden": "bool",
 
-    "edit_history": "Vec<PostHistoryRecord>",
-
     "direct_replies_count": "u16",
     "total_replies_count": "u32",
 
@@ -28,11 +26,6 @@
     "space_id": "Option<SpaceId>",
     "content": "Option<Content>",
     "hidden": "Option<bool>"
-  },
-
-  "PostHistoryRecord": {
-    "edited": "WhoAndWhen",
-    "old_data": "PostUpdate"
   },
 
   "PostExtension": {

--- a/pallets/profile-follows/src/lib.rs
+++ b/pallets/profile-follows/src/lib.rs
@@ -25,7 +25,7 @@ pub trait Trait: system::Trait
 
 // This pallet's storage items.
 decl_storage! {
-    trait Store for Module<T: Trait> as TemplateModule {
+    trait Store for Module<T: Trait> as ProfileFollowsModule {
         pub AccountFollowers get(fn account_followers): map T::AccountId => Vec<T::AccountId>;
         pub AccountFollowedByAccount get(fn account_followed_by_account): map (T::AccountId, T::AccountId) => bool;
         pub AccountsFollowedByAccount get(fn accounts_followed_by_account): map T::AccountId => Vec<T::AccountId>;

--- a/pallets/profile-history/Cargo.toml
+++ b/pallets/profile-history/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
-name = "pallet-spaces"
+name = "pallet-profile-history"
 version = "2.0.0"
 authors = ["DappForce <dappforce@pm.me>"]
 edition = "2018"
 license = "GPL-3.0-only"
 homepage = "https://subsocial.network"
 repository = "https://github.com/dappforce/dappforce-subsocial-node"
-description = "Space management pallet"
+description = "Pallet that stores profile updates history"
 keywords = ["blockchain", "cryptocurrency", "social-network", "news-feed", "marketplace"]
 categories = ["cryptography::cryptocurrencies"]
 
@@ -19,12 +19,8 @@ std = [
     'system/std',
     'sp-std/std',
     'pallet-utils/std',
-    'df-traits/std',
-    'pallet-permissions/std'
+    'pallet-profiles/std'
 ]
-
-[dependencies.impl-trait-for-tuples]
-version = "0.1.3"
 
 [dependencies.codec]
 default-features = false
@@ -57,17 +53,12 @@ git = 'https://github.com/paritytech/substrate.git'
 rev = '3e651110aa06aa835790df63410a29676243fc54'
 version = '2.0.0'
 
-[dependencies.df-traits]
-default-features = false
-path = '../traits'
-version = '2.0.0'
-
 [dependencies.pallet-utils]
 default-features = false
 path = '../utils'
 version = '2.0.0'
 
-[dependencies.pallet-permissions]
+[dependencies.pallet-profiles]
 default-features = false
-path = '../permissions'
+path = '../profiles'
 version = '2.0.0'

--- a/pallets/profile-history/Cargo.toml
+++ b/pallets/profile-history/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 license = "GPL-3.0-only"
 homepage = "https://subsocial.network"
 repository = "https://github.com/dappforce/dappforce-subsocial-node"
-description = "Pallet that stores profile updates history"
+description = "Pallet that stores profile edit history"
 keywords = ["blockchain", "cryptocurrency", "social-network", "news-feed", "marketplace"]
 categories = ["cryptography::cryptocurrencies"]
 

--- a/pallets/profile-history/src/lib.rs
+++ b/pallets/profile-history/src/lib.rs
@@ -1,0 +1,51 @@
+#![cfg_attr(not(feature = "std"), no_std)]
+#![allow(clippy::string_lit_as_bytes)]
+
+use codec::{Decode, Encode};
+use frame_support::{decl_module, decl_storage};
+use sp_runtime::RuntimeDebug;
+use sp_std::prelude::Vec;
+
+use pallet_utils::WhoAndWhen;
+use pallet_profiles::{Profile, ProfileUpdate, AfterProfileUpdated};
+
+#[derive(Encode, Decode, Clone, Eq, PartialEq, RuntimeDebug)]
+pub struct ProfileHistoryRecord<T: Trait> {
+    pub edited: WhoAndWhen<T>,
+    pub old_data: ProfileUpdate,
+}
+
+/// The pallet's configuration trait.
+pub trait Trait: system::Trait
+    + pallet_utils::Trait
+    + pallet_profiles::Trait
+{}
+
+// This pallet's storage items.
+decl_storage! {
+    trait Store for Module<T: Trait> as TemplateModule {
+        pub ProfileHistoryByAccount get(fn profile_history_by_account): map T::AccountId => Vec<ProfileHistoryRecord<T>>;
+    }
+}
+
+decl_module! {
+  pub struct Module<T: Trait> for enum Call where origin: T::Origin {}
+}
+
+impl<T: Trait> ProfileHistoryRecord<T> {
+    fn new(updated_by: T::AccountId) -> Self {
+        ProfileHistoryRecord {
+            edited: WhoAndWhen::<T>::new(updated_by),
+            old_data: ProfileUpdate::default()
+        }
+    }
+}
+
+impl<T: Trait> AfterProfileUpdated<T> for Module<T> {
+    fn after_profile_updated(sender: T::AccountId, _profile: &Profile<T>, old_data: ProfileUpdate) {
+        let mut new_history_record = ProfileHistoryRecord::<T>::new(sender.clone());
+        new_history_record.old_data = old_data;
+
+        <ProfileHistoryByAccount<T>>::mutate(sender, |ids| ids.push(new_history_record));
+    }
+}

--- a/pallets/profile-history/src/lib.rs
+++ b/pallets/profile-history/src/lib.rs
@@ -23,8 +23,8 @@ pub trait Trait: system::Trait
 
 // This pallet's storage items.
 decl_storage! {
-    trait Store for Module<T: Trait> as TemplateModule {
-        pub ProfileHistoryByAccount get(fn profile_history_by_account): map T::AccountId => Vec<ProfileHistoryRecord<T>>;
+    trait Store for Module<T: Trait> as ProfileHistoryModule {
+        pub EditHistory get(fn edit_history): map T::AccountId => Vec<ProfileHistoryRecord<T>>;
     }
 }
 
@@ -46,6 +46,6 @@ impl<T: Trait> AfterProfileUpdated<T> for Module<T> {
         let mut new_history_record = ProfileHistoryRecord::<T>::new(sender.clone());
         new_history_record.old_data = old_data;
 
-        <ProfileHistoryByAccount<T>>::mutate(sender, |ids| ids.push(new_history_record));
+        <EditHistory<T>>::mutate(sender, |ids| ids.push(new_history_record));
     }
 }

--- a/pallets/profile-history/src/lib.rs
+++ b/pallets/profile-history/src/lib.rs
@@ -33,19 +33,17 @@ decl_module! {
 }
 
 impl<T: Trait> ProfileHistoryRecord<T> {
-    fn new(updated_by: T::AccountId) -> Self {
+    fn new(updated_by: T::AccountId, old_data: ProfileUpdate) -> Self {
         ProfileHistoryRecord {
             edited: WhoAndWhen::<T>::new(updated_by),
-            old_data: ProfileUpdate::default()
+            old_data
         }
     }
 }
 
 impl<T: Trait> AfterProfileUpdated<T> for Module<T> {
     fn after_profile_updated(sender: T::AccountId, _profile: &Profile<T>, old_data: ProfileUpdate) {
-        let mut new_history_record = ProfileHistoryRecord::<T>::new(sender.clone());
-        new_history_record.old_data = old_data;
-
-        <EditHistory<T>>::mutate(sender, |ids| ids.push(new_history_record));
+        <EditHistory<T>>::mutate(sender.clone(), |ids|
+            ids.push(ProfileHistoryRecord::<T>::new(sender, old_data)));
     }
 }

--- a/pallets/profile-history/types.json
+++ b/pallets/profile-history/types.json
@@ -1,0 +1,6 @@
+{
+  "ProfileHistoryRecord": {
+    "edited": "WhoAndWhen",
+    "old_data": "ProfileUpdate"
+  }
+}

--- a/pallets/profiles/Cargo.toml
+++ b/pallets/profiles/Cargo.toml
@@ -22,6 +22,9 @@ std = [
     'pallet-permissions/std'
 ]
 
+[dependencies.impl-trait-for-tuples]
+version = "0.1.3"
+
 [dependencies.codec]
 default-features = false
 features = ['derive']

--- a/pallets/profiles/src/lib.rs
+++ b/pallets/profiles/src/lib.rs
@@ -56,7 +56,7 @@ pub trait Trait: system::Trait
 
 // This pallet's storage items.
 decl_storage! {
-    trait Store for Module<T: Trait> as TemplateModule {
+    trait Store for Module<T: Trait> as ProfilesModule {
         pub SocialAccountById get(fn social_account_by_id): map T::AccountId => Option<SocialAccount<T>>;
         pub AccountByProfileUsername get(fn account_by_profile_username): map Vec<u8> => Option<T::AccountId>;
     }

--- a/pallets/profiles/types.json
+++ b/pallets/profiles/types.json
@@ -12,18 +12,11 @@
     "updated": "Option<WhoAndWhen>",
 
     "username": "Text",
-    "content": "Content",
-
-    "edit_history": "Vec<ProfileHistoryRecord>"
+    "content": "Content"
   },
 
   "ProfileUpdate": {
     "username": "Option<Text>",
     "content": "Option<Content>"
-  },
-
-  "ProfileHistoryRecord": {
-    "edited": "WhoAndWhen",
-    "old_data": "ProfileUpdate"
   }
 }

--- a/pallets/reactions/src/lib.rs
+++ b/pallets/reactions/src/lib.rs
@@ -53,7 +53,7 @@ pub trait Trait: system::Trait
 
 // This pallet's storage items.
 decl_storage! {
-    trait Store for Module<T: Trait> as TemplateModule {
+    trait Store for Module<T: Trait> as ReactionsModule {
         pub NextReactionId get(fn next_reaction_id): ReactionId = 1;
         pub ReactionById get(fn reaction_by_id): map ReactionId => Option<Reaction<T>>;
         pub ReactionIdsByPostId get(fn reaction_ids_by_post_id): map PostId => Vec<ReactionId>;

--- a/pallets/scores/src/lib.rs
+++ b/pallets/scores/src/lib.rs
@@ -78,7 +78,7 @@ decl_error! {
 
 // This pallet's storage items.
 decl_storage! {
-    trait Store for Module<T: Trait> as TemplateModule {
+    trait Store for Module<T: Trait> as ScoresModule {
 
         // TODO shorten name? (refactor)
         pub AccountReputationDiffByAccount get(fn account_reputation_diff_by_account):

--- a/pallets/space-follows/src/lib.rs
+++ b/pallets/space-follows/src/lib.rs
@@ -44,7 +44,7 @@ decl_error! {
 
 // This pallet's storage items.
 decl_storage! {
-    trait Store for Module<T: Trait> as TemplateModule {
+    trait Store for Module<T: Trait> as SpaceFollowsModule {
         pub SpaceFollowers get(fn space_followers): map SpaceId => Vec<T::AccountId>;
         pub SpaceFollowedByAccount get(fn space_followed_by_account): map (T::AccountId, SpaceId) => bool;
         pub SpacesFollowedByAccount get(fn spaces_followed_by_account): map T::AccountId => Vec<SpaceId>;

--- a/pallets/space-history/Cargo.toml
+++ b/pallets/space-history/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
-name = "pallet-spaces"
+name = "pallet-space-history"
 version = "2.0.0"
 authors = ["DappForce <dappforce@pm.me>"]
 edition = "2018"
 license = "GPL-3.0-only"
 homepage = "https://subsocial.network"
 repository = "https://github.com/dappforce/dappforce-subsocial-node"
-description = "Space management pallet"
+description = "Pallet that stores space updates history"
 keywords = ["blockchain", "cryptocurrency", "social-network", "news-feed", "marketplace"]
 categories = ["cryptography::cryptocurrencies"]
 
@@ -18,13 +18,9 @@ std = [
     'frame-support/std',
     'system/std',
     'sp-std/std',
-    'pallet-utils/std',
-    'df-traits/std',
-    'pallet-permissions/std'
+    'pallet-spaces/std',
+    'pallet-utils/std'
 ]
-
-[dependencies.impl-trait-for-tuples]
-version = "0.1.3"
 
 [dependencies.codec]
 default-features = false
@@ -57,17 +53,12 @@ git = 'https://github.com/paritytech/substrate.git'
 rev = '3e651110aa06aa835790df63410a29676243fc54'
 version = '2.0.0'
 
-[dependencies.df-traits]
+[dependencies.pallet-spaces]
 default-features = false
-path = '../traits'
+path = '../spaces'
 version = '2.0.0'
 
 [dependencies.pallet-utils]
 default-features = false
 path = '../utils'
-version = '2.0.0'
-
-[dependencies.pallet-permissions]
-default-features = false
-path = '../permissions'
 version = '2.0.0'

--- a/pallets/space-history/Cargo.toml
+++ b/pallets/space-history/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 license = "GPL-3.0-only"
 homepage = "https://subsocial.network"
 repository = "https://github.com/dappforce/dappforce-subsocial-node"
-description = "Pallet that stores space updates history"
+description = "Pallet that stores space edit history"
 keywords = ["blockchain", "cryptocurrency", "social-network", "news-feed", "marketplace"]
 categories = ["cryptography::cryptocurrencies"]
 

--- a/pallets/space-history/src/lib.rs
+++ b/pallets/space-history/src/lib.rs
@@ -1,0 +1,52 @@
+#![cfg_attr(not(feature = "std"), no_std)]
+#![allow(clippy::string_lit_as_bytes)]
+
+use codec::{Decode, Encode};
+use frame_support::{decl_module, decl_storage};
+use sp_runtime::RuntimeDebug;
+use sp_std::prelude::Vec;
+
+use pallet_utils::{SpaceId, WhoAndWhen};
+use pallet_spaces::{Space, SpaceUpdate, AfterSpaceUpdated};
+
+#[derive(Encode, Decode, Clone, Eq, PartialEq, RuntimeDebug)]
+pub struct SpaceHistoryRecord<T: Trait> {
+    pub edited: WhoAndWhen<T>,
+    pub old_data: SpaceUpdate,
+}
+
+/// The pallet's configuration trait.
+pub trait Trait: system::Trait
+    + pallet_spaces::Trait
+    + pallet_utils::Trait
+{}
+
+// This pallet's storage items.
+decl_storage! {
+    trait Store for Module<T: Trait> as SpaceHistoryModule {
+        pub SpaceHistoryBySpaceId get(fn space_history_by_space_id): map SpaceId => Vec<SpaceHistoryRecord<T>>;
+    }
+}
+
+// The pallet's dispatchable functions.
+decl_module! {
+  pub struct Module<T: Trait> for enum Call where origin: T::Origin {}
+}
+
+impl<T: Trait> SpaceHistoryRecord<T> {
+    fn new(updated_by: T::AccountId) -> Self {
+        SpaceHistoryRecord {
+            edited: WhoAndWhen::<T>::new(updated_by),
+            old_data: SpaceUpdate::default()
+        }
+    }
+}
+
+impl<T: Trait> AfterSpaceUpdated<T> for Module<T> {
+    fn after_space_updated(sender: T::AccountId, space: &Space<T>, old_data: SpaceUpdate) {
+        let mut new_history_record = SpaceHistoryRecord::<T>::new(sender);
+        new_history_record.old_data = old_data;
+
+        <SpaceHistoryBySpaceId<T>>::mutate(space.id, |ids| ids.push(new_history_record));
+    }
+}

--- a/pallets/space-history/src/lib.rs
+++ b/pallets/space-history/src/lib.rs
@@ -24,7 +24,7 @@ pub trait Trait: system::Trait
 // This pallet's storage items.
 decl_storage! {
     trait Store for Module<T: Trait> as SpaceHistoryModule {
-        pub SpaceHistoryBySpaceId get(fn space_history_by_space_id): map SpaceId => Vec<SpaceHistoryRecord<T>>;
+        pub EditHistory get(fn edit_history): map SpaceId => Vec<SpaceHistoryRecord<T>>;
     }
 }
 
@@ -47,6 +47,6 @@ impl<T: Trait> AfterSpaceUpdated<T> for Module<T> {
         let mut new_history_record = SpaceHistoryRecord::<T>::new(sender);
         new_history_record.old_data = old_data;
 
-        <SpaceHistoryBySpaceId<T>>::mutate(space.id, |ids| ids.push(new_history_record));
+        <EditHistory<T>>::mutate(space.id, |ids| ids.push(new_history_record));
     }
 }

--- a/pallets/space-history/src/lib.rs
+++ b/pallets/space-history/src/lib.rs
@@ -34,19 +34,17 @@ decl_module! {
 }
 
 impl<T: Trait> SpaceHistoryRecord<T> {
-    fn new(updated_by: T::AccountId) -> Self {
+    fn new(updated_by: T::AccountId, old_data: SpaceUpdate) -> Self {
         SpaceHistoryRecord {
             edited: WhoAndWhen::<T>::new(updated_by),
-            old_data: SpaceUpdate::default()
+            old_data
         }
     }
 }
 
 impl<T: Trait> AfterSpaceUpdated<T> for Module<T> {
     fn after_space_updated(sender: T::AccountId, space: &Space<T>, old_data: SpaceUpdate) {
-        let mut new_history_record = SpaceHistoryRecord::<T>::new(sender);
-        new_history_record.old_data = old_data;
-
-        <EditHistory<T>>::mutate(space.id, |ids| ids.push(new_history_record));
+        <EditHistory<T>>::mutate(space.id, |ids|
+            ids.push(SpaceHistoryRecord::<T>::new(sender, old_data)));
     }
 }

--- a/pallets/space-history/types.json
+++ b/pallets/space-history/types.json
@@ -1,0 +1,6 @@
+{
+  "SpaceHistoryRecord": {
+    "edited": "WhoAndWhen",
+    "old_data": "SpaceUpdate"
+  }
+}

--- a/pallets/space-ownership/src/lib.rs
+++ b/pallets/space-ownership/src/lib.rs
@@ -37,7 +37,7 @@ decl_error! {
 
 // This pallet's storage items.
 decl_storage! {
-    trait Store for Module<T: Trait> as TemplateModule {
+    trait Store for Module<T: Trait> as SpaceOwnershipModule {
         pub PendingSpaceOwner get(fn pending_space_owner): map SpaceId => Option<T::AccountId>;
     }
 }

--- a/pallets/spaces/src/lib.rs
+++ b/pallets/spaces/src/lib.rs
@@ -330,10 +330,10 @@ impl<T: Trait> Space<T> {
 impl Default for SpaceUpdate {
     fn default() -> Self {
         SpaceUpdate {
+            parent_id: None,
             handle: None,
             content: None,
             hidden: None,
-            parent_id: None
         }
     }
 }

--- a/pallets/spaces/src/lib.rs
+++ b/pallets/spaces/src/lib.rs
@@ -35,8 +35,6 @@ pub struct Space<T: Trait> {
     pub posts_count: u16,
     pub followers_count: u32,
 
-    pub edit_history: Vec<SpaceHistoryRecord<T>>,
-
     pub score: i32,
 
     /// Allows to override the default permissions for this space.
@@ -50,12 +48,6 @@ pub struct SpaceUpdate {
     pub handle: Option<Option<Vec<u8>>>,
     pub content: Option<Content>,
     pub hidden: Option<bool>,
-}
-
-#[derive(Encode, Decode, Clone, Eq, PartialEq, RuntimeDebug)]
-pub struct SpaceHistoryRecord<T: Trait> {
-    pub edited: WhoAndWhen<T>,
-    pub old_data: SpaceUpdate,
 }
 
 /// The pallet's configuration trait.
@@ -76,6 +68,8 @@ pub trait Trait: system::Trait
     type SpaceFollows: SpaceFollowsProvider<AccountId=Self::AccountId>;
 
     type BeforeSpaceCreated: BeforeSpaceCreated<Self>;
+
+    type AfterSpaceUpdated: AfterSpaceUpdated<Self>;
 }
 
 decl_error! {
@@ -201,15 +195,7 @@ decl_module! {
       )?;
 
       let mut fields_updated = 0;
-      let mut new_history_record = SpaceHistoryRecord {
-        edited: WhoAndWhen::<T>::new(owner.clone()),
-        old_data: SpaceUpdate {
-            parent_id: None,
-            handle: None,
-            content: None,
-            hidden: None
-        }
-      };
+      let mut old_data = SpaceUpdate::default();
 
       // TODO: add tests for this case
       if let Some(parent_id_opt) = update.parent_id {
@@ -226,7 +212,7 @@ decl_module! {
             )?;
           }
 
-          new_history_record.old_data.parent_id = Some(space.parent_id);
+          old_data.parent_id = Some(space.parent_id);
           space.parent_id = parent_id_opt;
           fields_updated += 1;
         }
@@ -235,7 +221,8 @@ decl_module! {
       if let Some(content) = update.content {
         if content != space.content {
           Utils::<T>::is_valid_content(content.clone())?;
-          new_history_record.old_data.content = Some(space.content);
+
+          old_data.content = Some(space.content);
           space.content = content;
           fields_updated += 1;
         }
@@ -243,7 +230,7 @@ decl_module! {
 
       if let Some(hidden) = update.hidden {
         if hidden != space.hidden {
-          new_history_record.old_data.hidden = Some(space.hidden);
+          old_data.hidden = Some(space.hidden);
           space.hidden = hidden;
           fields_updated += 1;
         }
@@ -258,7 +245,7 @@ decl_module! {
           if let Some(old_handle) = space.handle.clone() {
             SpaceIdByHandle::remove(old_handle);
           }
-          new_history_record.old_data.handle = Some(space.handle);
+          old_data.handle = Some(space.handle);
           space.handle = handle_opt;
           fields_updated += 1;
         }
@@ -267,8 +254,10 @@ decl_module! {
       // Update this space only if at least one field should be updated:
       if fields_updated > 0 {
         space.updated = Some(WhoAndWhen::<T>::new(owner.clone()));
-        space.edit_history.push(new_history_record);
-        <SpaceById<T>>::insert(space_id, space);
+
+        <SpaceById<T>>::insert(space_id, space.clone());
+        T::AfterSpaceUpdated::after_space_updated(owner.clone(), &space, old_data);
+
         Self::deposit_event(RawEvent::SpaceUpdated(owner, space_id));
       }
     }
@@ -294,7 +283,6 @@ impl<T: Trait> Space<T> {
             hidden: false,
             posts_count: 0,
             followers_count: 0,
-            edit_history: Vec::new(),
             score: 0,
             permissions: None,
         }
@@ -335,6 +323,17 @@ impl<T: Trait> Space<T> {
             self.score = self.score.saturating_add(diff.abs() as i32);
         } else if diff < 0 {
             self.score = self.score.saturating_sub(diff.abs() as i32);
+        }
+    }
+}
+
+impl Default for SpaceUpdate {
+    fn default() -> Self {
+        SpaceUpdate {
+            handle: None,
+            content: None,
+            hidden: None,
+            parent_id: None
         }
     }
 }
@@ -419,4 +418,9 @@ impl<T: Trait> BeforeSpaceCreated<T> for () {
     fn before_space_created(_follower: T::AccountId, _space: &mut Space<T>) -> DispatchResult {
         Ok(())
     }
+}
+
+#[impl_trait_for_tuples::impl_for_tuples(10)]
+pub trait AfterSpaceUpdated<T: Trait> {
+    fn after_space_updated(sender: T::AccountId, space: &Space<T>, old_data: SpaceUpdate);
 }

--- a/pallets/spaces/src/lib.rs
+++ b/pallets/spaces/src/lib.rs
@@ -97,7 +97,7 @@ decl_error! {
 
 // This pallet's storage items.
 decl_storage! {
-    trait Store for Module<T: Trait> as TemplateModule {
+    trait Store for Module<T: Trait> as SpacesModule {
 
         // TODO reserve space id 0 (zero) for 'Abyss'.
 

--- a/pallets/spaces/types.json
+++ b/pallets/spaces/types.json
@@ -14,8 +14,6 @@
     "posts_count": "u16",
     "followers_count": "u32",
 
-    "edit_history": "Vec<SpaceHistoryRecord>",
-
     "score": "i32",
 
     "permissions": "Option<SpacePermissions>"
@@ -26,10 +24,5 @@
     "handle": "Option<Option<Text>>",
     "content": "Option<Content>",
     "hidden": "Option<bool>"
-  },
-
-  "SpaceHistoryRecord": {
-    "edited": "WhoAndWhen",
-    "old_data": "SpaceUpdate"
   }
 }

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -41,14 +41,17 @@ std = [
     "transaction-payment/std",
     "pallet-permissions/std",
     "pallet-posts/std",
+    "pallet-post-history/std",
     "pallet-profiles/std",
     "pallet-profile-follows/std",
+    "pallet-profile-history/std",
     "pallet-reactions/std",
     "pallet-roles/std",
     "pallet-scores/std",
     "pallet-spaces/std",
     "pallet-space-follows/std",
     "pallet-space-ownership/std",
+    "pallet-space-history/std",
     "pallet-utils/std"
 ]
 
@@ -226,6 +229,10 @@ path = "../pallets/permissions"
 default-features = false
 path = "../pallets/posts"
 
+[dependencies.pallet-post-history]
+default-features = false
+path = "../pallets/post-history"
+
 [dependencies.pallet-profiles]
 default-features = false
 path = "../pallets/profiles"
@@ -233,6 +240,10 @@ path = "../pallets/profiles"
 [dependencies.pallet-profile-follows]
 default-features = false
 path = "../pallets/profile-follows"
+
+[dependencies.pallet-profile-history]
+default-features = false
+path = "../pallets/profile-history"
 
 [dependencies.pallet-reactions]
 default-features = false
@@ -257,6 +268,10 @@ path = "../pallets/space-follows"
 [dependencies.pallet-space-ownership]
 default-features = false
 path = "../pallets/space-ownership"
+
+[dependencies.pallet-space-history]
+default-features = false
+path = "../pallets/space-history"
 
 [dependencies.pallet-utils]
 default-features = false

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -327,7 +327,12 @@ impl pallet_posts::Trait for Runtime {
   type Event = Event;
   type MaxCommentDepth = MaxCommentDepth;
   type PostScores = Scores;
+  type AfterPostUpdated = PostHistory;
 }
+
+parameter_types! {}
+
+impl pallet_post_history::Trait for Runtime {}
 
 parameter_types! {}
 
@@ -346,7 +351,12 @@ impl pallet_profiles::Trait for Runtime {
   type Event = Event;
   type MinUsernameLen = MinUsernameLen;
   type MaxUsernameLen = MaxUsernameLen;
+  type AfterProfileUpdated = ProfileHistory;
 }
+
+parameter_types! {}
+
+impl pallet_profile_history::Trait for Runtime {}
 
 parameter_types! {}
 
@@ -422,7 +432,12 @@ impl pallet_spaces::Trait for Runtime {
   type Roles = Roles;
   type SpaceFollows = SpaceFollows;
   type BeforeSpaceCreated = SpaceFollows;
+  type AfterSpaceUpdated = SpaceHistory;
 }
+
+parameter_types! {}
+
+impl pallet_space_history::Trait for Runtime {}
 
 construct_runtime!(
   pub enum Runtime where
@@ -444,12 +459,15 @@ construct_runtime!(
     // Subsocial custom pallets:
     Permissions: pallet_permissions::{Module, Call /* TODO inspect: do we need Call for permissions? */},
     Posts: pallet_posts::{Module, Call, Storage, Event<T>},
+    PostHistory: pallet_post_history::{Module, Storage},
     ProfileFollows: pallet_profile_follows::{Module, Call, Storage, Event<T>},
     Profiles: pallet_profiles::{Module, Call, Storage, Event<T>},
+    ProfileHistory: pallet_profile_history::{Module, Storage},
     Reactions: pallet_reactions::{Module, Call, Storage, Event<T>},
     Roles: pallet_roles::{Module, Call, Storage, Event<T>},
     Scores: pallet_scores::{Module, Call, Storage, Event<T>},
     SpaceFollows: pallet_space_follows::{Module, Call, Storage, Event<T>},
+    SpaceHistory: pallet_space_history::{Module, Storage},
     SpaceOwnership: pallet_space_ownership::{Module, Call, Storage, Event<T>},
     Spaces: pallet_spaces::{Module, Call, Storage, Event<T>},
   }


### PR DESCRIPTION
- Includes moving space, post and profile history out of their pallets.

Substrate to Rust compatibility issue is on this branch. To fix this, build should be ran with `Rust 1.46.0 nightly-2020-06-23`:
```sh
rustup override set nightly-2020-06-23
rustup target add wasm32-unknown-unknown --toolchain nightly-2020-06-23
```